### PR TITLE
Refactor caching and clean templates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ FINNHUB_API_KEY_2=your_alternate_finnhub_api_key_here
 
 # Discord Channel Configuration
 DISCORD_CHANNEL_ID=your_discord_channel_id_here
+
+# Dashboard caching and rate limiting
+DASHBOARD_CACHE_DURATION=300
+MIN_REQUEST_INTERVAL=2

--- a/dashboard_robinhood.py
+++ b/dashboard_robinhood.py
@@ -1,9 +1,8 @@
 # Enhanced Trading Game Dashboard - Robinhood Style
-from flask import Flask, render_template_string, url_for, redirect, jsonify
+from flask import Flask, render_template, url_for, redirect, jsonify
 import sqlite3
 import requests
 from datetime import datetime, date
-import json
 import os
 import time
 from dotenv import load_dotenv
@@ -20,13 +19,19 @@ FINNHUB_API_KEY_2 = os.getenv("FINNHUB_API_KEY_2")  # Alternative naming
 DB_NAME = "trading_game.db"
 APP_NAME = "Trading Dashboard"
 
-app = Flask(__name__)
+app = Flask(__name__, template_folder="templates")
 
 # Module-level price cache with timestamps (shared with bot)
 price_cache = {}
 CACHE_DURATION = 60  # seconds
 CACHE_TTL = 60  # seconds (for consistency with bot)
 rate_limit_until = 0  # timestamp until we should avoid API calls
+last_request_time = 0  # throttle API requests
+MIN_REQUEST_INTERVAL = float(os.getenv("MIN_REQUEST_INTERVAL", 2))
+
+# Cached leaderboard data to minimize API usage
+dashboard_data = {"leaderboard": None, "summary": None, "timestamp": 0}
+DASHBOARD_CACHE_DURATION = int(os.getenv("DASHBOARD_CACHE_DURATION", 300))
 
 # ──────────────────────────────────────────────────────────────
 # Helper Functions
@@ -74,9 +79,38 @@ def get_last_price_from_db(symbol: str) -> float | None:
         conn.close()
     return None
 
+def save_price_to_db(symbol: str, price: float) -> None:
+    """Persist latest price to the database."""
+    conn = sqlite3.connect(DB_NAME)
+    cursor = conn.cursor()
+    cursor.execute(
+        "INSERT OR REPLACE INTO last_price (symbol, price, last_updated) VALUES (?, ?, CURRENT_TIMESTAMP)",
+        (symbol.upper(), price),
+    )
+    conn.commit()
+    conn.close()
+
+def get_price_yahoo(symbol: str) -> float | None:
+    """Fetch price from Yahoo Finance as a fallback."""
+    url = f"https://query1.finance.yahoo.com/v7/finance/quote?symbols={symbol}"
+    global last_request_time
+    try:
+        resp = requests.get(url, timeout=5)
+        last_request_time = time.time()
+        if resp.status_code == 200:
+            data = resp.json()
+            result = data.get("quoteResponse", {}).get("result", [])
+            if result:
+                price = result[0].get("regularMarketPrice")
+                if price and price > 0:
+                    return price
+    except Exception as exc:
+        print(f"Yahoo Finance error for {symbol}: {exc}")
+    return None
+
 def get_price(symbol: str) -> float | None:
     """Get stock price with caching and rate limit handling."""
-    global rate_limit_until
+    global rate_limit_until, last_request_time
     cache_key = symbol.upper()
     current_time = time.time()
     
@@ -86,6 +120,16 @@ def get_price(symbol: str) -> float | None:
         if current_time - cached_time < CACHE_DURATION:
             return cached_price
     
+    # Throttle requests to avoid excessive API usage
+    if current_time - last_request_time < MIN_REQUEST_INTERVAL:
+        if cache_key in price_cache:
+            cached_price, _ = price_cache[cache_key]
+            return cached_price
+        db_price = get_last_price_from_db(symbol)
+        if db_price:
+            return db_price
+        return None
+
     # Check if we're in a rate limit period
     if current_time < rate_limit_until:
         # Return cached price if available during rate limit
@@ -101,6 +145,7 @@ def get_price(symbol: str) -> float | None:
     
     try:
         response = requests.get(url, timeout=5)
+        last_request_time = time.time()
         
         if response.status_code == 429:
             # Rate limited - set rate limit period and try secondary key
@@ -110,13 +155,15 @@ def get_price(symbol: str) -> float | None:
             if FINNHUB_API_KEY_SECOND:
                 url_secondary = f"https://finnhub.io/api/v1/quote?symbol={symbol}&token={FINNHUB_API_KEY_SECOND}"
                 response_secondary = requests.get(url_secondary, timeout=5)
-                
+                last_request_time = time.time()
+
                 if response_secondary.status_code == 200:
                     data = response_secondary.json()
                     price = data.get("c")
                     if price and price > 0:
                         # Cache the result
                         price_cache[cache_key] = (price, current_time)
+                        save_price_to_db(symbol, price)
                         return price
                 elif response_secondary.status_code == 429:
                     print(f"Secondary key also rate limited for {symbol}")
@@ -125,13 +172,15 @@ def get_price(symbol: str) -> float | None:
             if FINNHUB_API_KEY_2:
                 url_alt = f"https://finnhub.io/api/v1/quote?symbol={symbol}&token={FINNHUB_API_KEY_2}"
                 response_alt = requests.get(url_alt, timeout=5)
-                
+                last_request_time = time.time()
+
                 if response_alt.status_code == 200:
                     data = response_alt.json()
                     price = data.get("c")
                     if price and price > 0:
                         # Cache the result
                         price_cache[cache_key] = (price, current_time)
+                        save_price_to_db(symbol, price)
                         return price
             
             # If both keys are rate limited, return cached price if available
@@ -147,9 +196,17 @@ def get_price(symbol: str) -> float | None:
             if price and price > 0:
                 # Cache the result
                 price_cache[cache_key] = (price, current_time)
+                save_price_to_db(symbol, price)
                 return price
         
-        # API call failed, return cached price if available
+        # API call failed, attempt Yahoo Finance fallback
+        yahoo_price = get_price_yahoo(symbol)
+        if yahoo_price:
+            price_cache[cache_key] = (yahoo_price, current_time)
+            save_price_to_db(symbol, yahoo_price)
+            return yahoo_price
+
+        # Use cached price if available
         if cache_key in price_cache:
             cached_price, _ = price_cache[cache_key]
             print(f"API call failed, using cached price for {symbol}: ${cached_price:.2f}")
@@ -157,24 +214,32 @@ def get_price(symbol: str) -> float | None:
         return None
         
     except Exception as e:
-        print(f"Error fetching price for {symbol}: {e}")        # Return cached price if available
+        print(f"Error fetching price for {symbol}: {e}")
+
+        yahoo_price = get_price_yahoo(symbol)
+        if yahoo_price:
+            price_cache[cache_key] = (yahoo_price, current_time)
+            save_price_to_db(symbol, yahoo_price)
+            return yahoo_price
+
         if cache_key in price_cache:
             cached_price, _ = price_cache[cache_key]
             return cached_price
-        
-        # Final fallback: query database for last known price
+
         db_price = get_last_price_from_db(symbol)
         if db_price:
             print(f"Using database fallback price for {symbol}: ${db_price:.2f}")
             return db_price
-        
+
         return None
 
 def get_company_name(symbol: str) -> str | None:
     """Return company name from Finnhub or None on failure."""
     url = f"https://finnhub.io/api/v1/stock/profile2?symbol={symbol}&token={FINNHUB_API_KEY}"
+    global last_request_time
     try:
         response = requests.get(url, timeout=5)
+        last_request_time = time.time()
         if response.status_code == 200:
             data = response.json()
             return data.get("name", None)
@@ -348,1034 +413,15 @@ def fetch_user_portfolio(user_id: str):
         "history_values": history_values
     }
 
-# ──────────────────────────────────────────────────────────────
-# HTML Templates - Robinhood Style
-# ──────────────────────────────────────────────────────────────
-INDEX_HTML = """
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ app_name }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <style>
-        /* Robinhood-Inspired Dark Theme */
-        :root {
-            --rh-black: #0B0E11;
-            --rh-dark: #1A1E23;
-            --rh-medium: #242932;
-            --rh-light: #2F343D;
-            --rh-border: #3A404A;
-            --rh-white: #FFFFFF;
-            --rh-text-primary: #FFFFFF;
-            --rh-text-secondary: #9CA0A6;
-            --rh-text-muted: #6B7280;
-            --rh-green: #00C805;
-            --rh-red: #FF5A52;
-            --rh-blue: #5AC53B;
-            --rh-purple: #8B5CF6;
-            --rh-yellow: #F7931E;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-            background: var(--rh-black);
-            color: var(--rh-text-primary);
-            font-size: 14px;
-            line-height: 1.5;
-            min-height: 100vh;
-            overflow-x: hidden;
-        }
-        
-        /* Navigation */
-        .navbar {
-            background: var(--rh-dark);
-            border-bottom: 1px solid var(--rh-border);
-            padding: 1rem 0;
-            position: sticky;
-            top: 0;
-            z-index: 100;
-            backdrop-filter: blur(10px);
-        }
-        
-        .nav-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 1rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        
-        .nav-brand {
-            font-size: 1.25rem;
-            font-weight: 700;
-            color: var(--rh-white);
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .nav-brand:hover {
-            color: var(--rh-blue);
-        }
-        
-        .nav-actions {
-            display: flex;
-            gap: 0.75rem;
-        }
-        
-        /* Buttons */
-        .btn {
-            padding: 0.5rem 1rem;
-            border-radius: 20px;
-            border: 1px solid transparent;
-            font-size: 13px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            text-decoration: none;
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .btn-primary {
-            background: var(--rh-blue);
-            color: var(--rh-black);
-            border-color: var(--rh-blue);
-        }
-        
-        .btn-primary:hover {
-            background: #4AB02A;
-            transform: translateY(-1px);
-        }
-        
-        .btn-outline {
-            background: transparent;
-            color: var(--rh-text-secondary);
-            border-color: var(--rh-border);
-        }
-        
-        .btn-outline:hover {
-            background: var(--rh-medium);
-            color: var(--rh-white);
-            border-color: var(--rh-light);
-        }
-        
-        /* Container */
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 2rem 1rem;
-        }
-        
-        /* Grid */
-        .grid {
-            display: grid;
-            gap: 1.5rem;
-        }
-        
-        .grid-4 {
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        }
-        
-        .grid-2 {
-            grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
-        }
-        
-        /* Cards */
-        .card {
-            background: var(--rh-dark);
-            border: 1px solid var(--rh-border);
-            border-radius: 12px;
-            overflow: hidden;
-            transition: all 0.2s ease;
-        }
-        
-        .card:hover {
-            border-color: var(--rh-light);
-            transform: translateY(-2px);
-        }
-        
-        .card-header {
-            padding: 1.25rem 1.5rem;
-            border-bottom: 1px solid var(--rh-border);
-            background: var(--rh-medium);
-        }
-        
-        .card-title {
-            font-size: 1rem;
-            font-weight: 600;
-            color: var(--rh-white);
-            margin: 0;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .card-body {
-            padding: 1.5rem;
-        }
-        
-        /* Metric Cards */
-        .metric-card {
-            text-align: center;
-            background: var(--rh-dark);
-            border: 1px solid var(--rh-border);
-            border-radius: 12px;
-            padding: 1.5rem;
-            transition: all 0.2s ease;
-        }
-        
-        .metric-card:hover {
-            border-color: var(--rh-light);
-            transform: translateY(-2px);
-        }
-        
-        .metric-icon {
-            font-size: 2rem;
-            margin-bottom: 0.75rem;
-            opacity: 0.8;
-        }
-        
-        .metric-label {
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--rh-text-secondary);
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            margin-bottom: 0.5rem;
-        }
-        
-        .metric-value {
-            font-size: 1.75rem;
-            font-weight: 700;
-            margin: 0;
-        }
-        
-        /* Table */
-        .table-container {
-            overflow-x: auto;
-            border-radius: 8px;
-            border: 1px solid var(--rh-border);
-        }
-        
-        .table {
-            width: 100%;
-            border-collapse: collapse;
-            background: var(--rh-dark);
-        }
-        
-        .table th {
-            background: var(--rh-medium);
-            color: var(--rh-text-secondary);
-            font-size: 12px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            padding: 1rem 0.75rem;
-            text-align: left;
-            border-bottom: 1px solid var(--rh-border);
-        }
-        
-        .table td {
-            padding: 1rem 0.75rem;
-            border-bottom: 1px solid var(--rh-border);
-            vertical-align: middle;
-        }
-        
-        .table tr:hover {
-            background: var(--rh-medium);
-        }
-        
-        .table tr:last-child td {
-            border-bottom: none;
-        }
-        
-        /* Colors */
-        .text-green {
-            color: var(--rh-green);
-            font-weight: 600;
-        }
-        
-        .text-red {
-            color: var(--rh-red);
-            font-weight: 600;
-        }
-        
-        .text-blue {
-            color: var(--rh-blue);
-        }
-        
-        .text-yellow {
-            color: var(--rh-yellow);
-        }
-        
-        .text-purple {
-            color: var(--rh-purple);
-        }
-        
-        .text-secondary {
-            color: var(--rh-text-secondary);
-        }
-        
-        .text-muted {
-            color: var(--rh-text-muted);
-            font-size: 13px;
-        }
-        
-        /* Badges */
-        .badge {
-            display: inline-flex;
-            align-items: center;
-            gap: 0.25rem;
-            padding: 0.25rem 0.75rem;
-            border-radius: 12px;
-            font-size: 12px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-        }
-        
-        .badge-gold {
-            background: linear-gradient(135deg, var(--rh-yellow), #E67E22);
-            color: var(--rh-black);
-        }
-        
-        .badge-silver {
-            background: var(--rh-text-secondary);
-            color: var(--rh-black);
-        }
-        
-        /* Charts */
-        .chart-container {
-            position: relative;
-            height: 300px;
-            background: var(--rh-medium);
-            border-radius: 8px;
-            padding: 1rem;
-        }
-        
-        /* Loading */
-        .loading {
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 0.5rem;
-            color: var(--rh-text-secondary);
-            font-size: 14px;
-        }
-        
-        .spinner {
-            width: 16px;
-            height: 16px;
-            border: 2px solid var(--rh-border);
-            border-top: 2px solid var(--rh-blue);
-            border-radius: 50%;
-            animation: spin 1s linear infinite;
-        }
-        
-        @keyframes spin {
-            0% { transform: rotate(0deg); }
-            100% { transform: rotate(360deg); }
-        }
-        
-        /* Responsive */
-        @media (max-width: 768px) {
-            .container {
-                padding: 1rem;
-            }
-            
-            .metric-card {
-                padding: 1rem;
-            }
-            
-            .metric-value {
-                font-size: 1.5rem;
-            }
-            
-            .table th,
-            .table td {
-                padding: 0.75rem 0.5rem;
-                font-size: 13px;
-            }
-        }
-    </style>
-</head>
-<body>
-    <!-- Navigation -->
-    <nav class="navbar">
-        <div class="nav-container">
-            <a href="/" class="nav-brand">
-                <i class="fas fa-chart-line"></i>
-                {{ app_name }}
-            </a>
-            <div class="nav-actions">
-                <button class="btn btn-primary" onclick="refreshData()">
-                    <i class="fas fa-sync-alt"></i>
-                    Refresh
-                </button>
-            </div>
-        </div>
-    </nav>
-
-    <div class="container">
-        <!-- Market Summary -->
-        <div class="grid grid-4" style="margin-bottom: 2rem;">
-            <div class="metric-card">
-                <div class="metric-icon text-blue">
-                    <i class="fas fa-users"></i>
-                </div>
-                <div class="metric-label">Active Traders</div>
-                <div class="metric-value text-blue">{{ summary.total_users }}</div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-green">
-                    <i class="fas fa-dollar-sign"></i>
-                </div>
-                <div class="metric-label">Total AUM</div>
-                <div class="metric-value text-green">${{ "{:,.0f}".format(summary.total_aum) }}</div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-yellow">
-                    <i class="fas fa-chart-line"></i>
-                </div>
-                <div class="metric-label">Avg ROI</div>
-                <div class="metric-value {% if summary.avg_roi >= 0 %}text-green{% else %}text-red{% endif %}">
-                    {{ "{:+.1f}".format(summary.avg_roi) }}%
-                </div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-purple">
-                    <i class="fas fa-trophy"></i>
-                </div>
-                <div class="metric-label">Best Performer</div>
-                <div class="metric-value text-purple">{{ summary.best_performer }}</div>
-            </div>
-        </div>
-
-        <!-- Leaderboard -->
-        <div class="card">
-            <div class="card-header">
-                <h2 class="card-title">
-                    <i class="fas fa-trophy text-yellow"></i>
-                    Leaderboard
-                </h2>
-            </div>
-            <div class="card-body" style="padding: 0;">
-                <div class="table-container">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th><i class="fas fa-medal"></i> Rank</th>
-                                <th><i class="fas fa-user"></i> Trader</th>
-                                <th><i class="fas fa-wallet"></i> Cash</th>
-                                <th><i class="fas fa-chart-pie"></i> Holdings</th>
-                                <th><i class="fas fa-money-bill"></i> Total Value</th>
-                                <th><i class="fas fa-percentage"></i> ROI</th>
-                                <th><i class="fas fa-chart-line"></i> P&L</th>
-                                <th><i class="fas fa-eye"></i> Actions</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for user in leaderboard %}
-                            <tr>
-                                <td>
-                                    {% if loop.index == 1 %}
-                                        <span class="badge badge-gold">
-                                            <i class="fas fa-crown"></i> {{ loop.index }}
-                                        </span>
-                                    {% elif loop.index <= 3 %}
-                                        <span class="badge badge-silver">{{ loop.index }}</span>
-                                    {% else %}
-                                        <span style="font-weight: 600;">{{ loop.index }}</span>
-                                    {% endif %}
-                                </td>
-                                <td>
-                                    <div>
-                                        <div style="font-weight: 600;">{{ user.name }}</div>
-                                        {% if user.total_holdings > 0 %}
-                                            <div class="text-muted">{{ user.total_holdings }} positions</div>
-                                        {% endif %}
-                                    </div>
-                                </td>
-                                <td>${{ "{:,.0f}".format(user.cash) }}</td>
-                                <td>${{ "{:,.0f}".format(user.holdings_value) }}</td>
-                                <td style="font-weight: 700;">${{ "{:,.0f}".format(user.total_value) }}</td>
-                                <td class="{% if user.roi >= 0 %}text-green{% else %}text-red{% endif %}">
-                                    {{ "{:+.1f}".format(user.roi) }}%
-                                </td>
-                                <td class="{% if user.pnl >= 0 %}text-green{% else %}text-red{% endif %}">
-                                    ${{ "{:+,.0f}".format(user.pnl) }}
-                                </td>
-                                <td>
-                                    <a href="/user/{{ user.user_id }}" class="btn btn-outline">
-                                        <i class="fas fa-chart-area"></i>
-                                        View Portfolio
-                                    </a>
-                                </td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    <script>
-        function refreshData() {
-            const spinner = document.querySelector('.spinner');
-            if (spinner) return; // Already refreshing
-            
-            const refreshBtn = document.querySelector('.btn-primary');
-            const originalContent = refreshBtn.innerHTML;
-            
-            refreshBtn.innerHTML = '<div class="spinner"></div> Refreshing...';
-            refreshBtn.disabled = true;
-            
-            setTimeout(() => {
-                location.reload();
-            }, 1000);
-        }
-    </script>
-</body>
-</html>
-"""
-
-USER_HTML = """
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{{ user.name }} - Portfolio | {{ app_name }}</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <style>
-        /* Same styles as INDEX_HTML for consistency */
-        :root {
-            --rh-black: #0B0E11;
-            --rh-dark: #1A1E23;
-            --rh-medium: #242932;
-            --rh-light: #2F343D;
-            --rh-border: #3A404A;
-            --rh-white: #FFFFFF;
-            --rh-text-primary: #FFFFFF;
-            --rh-text-secondary: #9CA0A6;
-            --rh-text-muted: #6B7280;
-            --rh-green: #00C805;
-            --rh-red: #FF5A52;
-            --rh-blue: #5AC53B;
-            --rh-purple: #8B5CF6;
-            --rh-yellow: #F7931E;
-        }
-        
-        * {
-            margin: 0;
-            padding: 0;
-            box-sizing: border-box;
-        }
-        
-        body {
-            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-            background: var(--rh-black);
-            color: var(--rh-text-primary);
-            font-size: 14px;
-            line-height: 1.5;
-            min-height: 100vh;
-            overflow-x: hidden;
-        }
-        
-        .navbar {
-            background: var(--rh-dark);
-            border-bottom: 1px solid var(--rh-border);
-            padding: 1rem 0;
-            position: sticky;
-            top: 0;
-            z-index: 100;
-        }
-        
-        .nav-container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 0 1rem;
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-        }
-        
-        .nav-brand {
-            font-size: 1.25rem;
-            font-weight: 700;
-            color: var(--rh-white);
-            text-decoration: none;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .btn {
-            padding: 0.5rem 1rem;
-            border-radius: 20px;
-            border: 1px solid transparent;
-            font-size: 13px;
-            font-weight: 500;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            text-decoration: none;
-            display: inline-flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .btn-outline {
-            background: transparent;
-            color: var(--rh-text-secondary);
-            border-color: var(--rh-border);
-        }
-        
-        .btn-outline:hover {
-            background: var(--rh-medium);
-            color: var(--rh-white);
-            border-color: var(--rh-light);
-        }
-        
-        .container {
-            max-width: 1200px;
-            margin: 0 auto;
-            padding: 2rem 1rem;
-        }
-        
-        .grid {
-            display: grid;
-            gap: 1.5rem;
-        }
-        
-        .grid-4 {
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-        }
-        
-        .grid-2 {
-            grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
-        }
-        
-        .card {
-            background: var(--rh-dark);
-            border: 1px solid var(--rh-border);
-            border-radius: 12px;
-            overflow: hidden;
-        }
-        
-        .card-header {
-            padding: 1.25rem 1.5rem;
-            border-bottom: 1px solid var(--rh-border);
-            background: var(--rh-medium);
-        }
-        
-        .card-title {
-            font-size: 1rem;
-            font-weight: 600;
-            color: var(--rh-white);
-            margin: 0;
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-        }
-        
-        .card-body {
-            padding: 1.5rem;
-        }
-        
-        .metric-card {
-            text-align: center;
-            background: var(--rh-dark);
-            border: 1px solid var(--rh-border);
-            border-radius: 12px;
-            padding: 1.5rem;
-            transition: all 0.2s ease;
-        }
-        
-        .metric-card:hover {
-            border-color: var(--rh-light);
-            transform: translateY(-2px);
-        }
-        
-        .metric-icon {
-            font-size: 2rem;
-            margin-bottom: 0.75rem;
-            opacity: 0.8;
-        }
-        
-        .metric-label {
-            font-size: 12px;
-            font-weight: 500;
-            color: var(--rh-text-secondary);
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            margin-bottom: 0.5rem;
-        }
-        
-        .metric-value {
-            font-size: 1.75rem;
-            font-weight: 700;
-            margin: 0;
-        }
-        
-        .table-container {
-            overflow-x: auto;
-            border-radius: 8px;
-            border: 1px solid var(--rh-border);
-        }
-        
-        .table {
-            width: 100%;
-            border-collapse: collapse;
-            background: var(--rh-dark);
-        }
-        
-        .table th {
-            background: var(--rh-medium);
-            color: var(--rh-text-secondary);
-            font-size: 12px;
-            font-weight: 600;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            padding: 1rem 0.75rem;
-            text-align: left;
-            border-bottom: 1px solid var(--rh-border);
-        }
-        
-        .table td {
-            padding: 1rem 0.75rem;
-            border-bottom: 1px solid var(--rh-border);
-            vertical-align: middle;
-        }
-        
-        .table tr:hover {
-            background: var(--rh-medium);
-        }
-        
-        .text-green {
-            color: var(--rh-green);
-            font-weight: 600;
-        }
-        
-        .text-red {
-            color: var(--rh-red);
-            font-weight: 600;
-        }
-        
-        .text-blue {
-            color: var(--rh-blue);
-        }
-        
-        .text-yellow {
-            color: var(--rh-yellow);
-        }
-        
-        .text-purple {
-            color: var(--rh-purple);
-        }
-        
-        .text-muted {
-            color: var(--rh-text-muted);
-            font-size: 13px;
-        }
-        
-        .chart-container {
-            position: relative;
-            height: 300px;
-            background: var(--rh-medium);
-            border-radius: 8px;
-            padding: 1rem;
-        }
-        
-        .page-title {
-            text-align: center;
-            margin-bottom: 2rem;
-            color: var(--rh-white);
-            font-size: 1.75rem;
-            font-weight: 700;
-        }
-        
-        @media (max-width: 768px) {
-            .container {
-                padding: 1rem;
-            }
-            
-            .metric-card {
-                padding: 1rem;
-            }
-            
-            .metric-value {
-                font-size: 1.5rem;
-            }
-        }
-    </style>
-</head>
-<body>
-    <!-- Navigation -->
-    <nav class="navbar">
-        <div class="nav-container">
-            <a href="/" class="nav-brand">
-                <i class="fas fa-chart-line"></i>
-                {{ app_name }}
-            </a>
-            <div class="nav-actions">
-                <a href="/" class="btn btn-outline">
-                    <i class="fas fa-arrow-left"></i>
-                    Back to Leaderboard
-                </a>
-            </div>
-        </div>
-    </nav>
-
-    <div class="container">
-        <!-- User Header -->
-        <h1 class="page-title">
-            <i class="fas fa-user-circle"></i>
-            {{ user.name }}'s Portfolio
-        </h1>
-
-        <!-- Portfolio Summary Cards -->
-        <div class="grid grid-4" style="margin-bottom: 2rem;">
-            <div class="metric-card">
-                <div class="metric-icon text-green">
-                    <i class="fas fa-wallet"></i>
-                </div>
-                <div class="metric-label">Cash</div>
-                <div class="metric-value text-green">${{ "{:,.0f}".format(user.cash) }}</div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-blue">
-                    <i class="fas fa-chart-pie"></i>
-                </div>
-                <div class="metric-label">Holdings Value</div>
-                <div class="metric-value text-blue">${{ "{:,.0f}".format(user.holdings_value) }}</div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-purple">
-                    <i class="fas fa-money-bill"></i>
-                </div>
-                <div class="metric-label">Total Value</div>
-                <div class="metric-value text-purple">${{ "{:,.0f}".format(user.total_value) }}</div>
-            </div>
-            
-            <div class="metric-card">
-                <div class="metric-icon text-yellow">
-                    <i class="fas fa-percentage"></i>
-                </div>
-                <div class="metric-label">ROI</div>
-                <div class="metric-value {% if user.roi >= 0 %}text-green{% else %}text-red{% endif %}">
-                    {{ "{:+.1f}".format(user.roi) }}%
-                </div>
-            </div>
-        </div>
-
-        <!-- Charts Row -->
-        <div class="grid grid-2" style="margin-bottom: 2rem;">
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title">
-                        <i class="fas fa-chart-pie"></i>
-                        Portfolio Allocation
-                    </h3>
-                </div>
-                <div class="card-body">
-                    <div class="chart-container">
-                        <canvas id="pieChart"></canvas>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title">
-                        <i class="fas fa-chart-line"></i>
-                        Performance Over Time
-                    </h3>
-                </div>
-                <div class="card-body">
-                    <div class="chart-container">
-                        <canvas id="lineChart"></canvas>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Holdings Table -->
-        {% if user.holdings %}
-        <div class="card">
-            <div class="card-header">
-                <h3 class="card-title">
-                    <i class="fas fa-list"></i>
-                    Holdings Details
-                </h3>
-            </div>
-            <div class="card-body" style="padding: 0;">
-                <div class="table-container">
-                    <table class="table">
-                        <thead>
-                            <tr>
-                                <th><i class="fas fa-tag"></i> Stock</th>
-                                <th><i class="fas fa-layer-group"></i> Shares</th>
-                                <th><i class="fas fa-dollar-sign"></i> Avg Cost</th>
-                                <th><i class="fas fa-chart-line"></i> Current Price</th>
-                                <th><i class="fas fa-money-bill"></i> Position Value</th>
-                                <th><i class="fas fa-percentage"></i> Price Change</th>
-                                <th><i class="fas fa-calculator"></i> Unrealized P&L</th>
-                                <th><i class="fas fa-chart-pie"></i> % of Portfolio</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for h in user.holdings %}
-                            <tr>
-                                <td>
-                                    <div>
-                                        <div style="font-weight: 600;">{{ h.symbol }}</div>
-                                        <div class="text-muted">{{ h.company_name }}</div>
-                                    </div>
-                                </td>
-                                <td>{{ "{:,.0f}".format(h.shares) }}</td>
-                                <td>${{ "{:.2f}".format(h.avg_price) }}</td>
-                                <td>${{ "{:.2f}".format(h.price) }}</td>
-                                <td style="font-weight: 700;">${{ "{:,.0f}".format(h.value) }}</td>
-                                <td class="{% if h.change >= 0 %}text-green{% else %}text-red{% endif %}">
-                                    {{ "{:+.1f}".format(h.change) }}%
-                                </td>
-                                <td class="{% if h.unrealized_pnl >= 0 %}text-green{% else %}text-red{% endif %}">
-                                    ${{ "{:+,.0f}".format(h.unrealized_pnl) }}
-                                </td>
-                                <td>{{ "{:.1f}".format(h.portfolio_percent) }}%</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        {% else %}
-        <div class="card">
-            <div class="card-body" style="text-align: center; padding: 3rem;">
-                <div style="font-size: 3rem; color: var(--rh-text-muted); margin-bottom: 1rem;">
-                    <i class="fas fa-chart-pie"></i>
-                </div>
-                <h3 style="color: var(--rh-text-secondary); margin-bottom: 0.5rem;">No Holdings Yet</h3>
-                <p class="text-muted">This portfolio consists entirely of cash.</p>
-            </div>
-        </div>
-        {% endif %}
-    </div>
-
-    <script>
-        // Chart.js configuration for consistent dark theme
-        Chart.defaults.color = '#9CA0A6';
-        Chart.defaults.borderColor = '#3A404A';
-        Chart.defaults.backgroundColor = '#242932';
-
-        // Pie Chart for Portfolio Allocation
-        {% if user.pie_labels|length > 0 %}
-        const pieCtx = document.getElementById('pieChart').getContext('2d');
-        new Chart(pieCtx, {
-            type: 'doughnut',
-            data: {
-                labels: {{ user.pie_labels|tojson }},
-                datasets: [{
-                    data: {{ user.pie_values|tojson }},
-                    backgroundColor: [
-                        '#00C805', '#FF5A52', '#5AC53B', '#8B5CF6', 
-                        '#F7931E', '#06B6D4', '#EF4444', '#10B981',
-                        '#F59E0B', '#8B5CF6'
-                    ],
-                    borderWidth: 2,
-                    borderColor: '#1A1E23'
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                plugins: {
-                    legend: { 
-                        position: 'right',
-                        labels: { 
-                            color: '#9CA0A6',
-                            usePointStyle: true,
-                            padding: 20
-                        }
-                    }
-                }
-            }
-        });
-        {% endif %}
-
-        // Line Chart for Historical Performance
-        {% if user.history_dates|length > 0 %}
-        const lineCtx = document.getElementById('lineChart').getContext('2d');
-        new Chart(lineCtx, {
-            type: 'line',
-            data: {
-                labels: {{ user.history_dates|tojson }},
-                datasets: [{
-                    label: 'Portfolio Value',
-                    data: {{ user.history_values|tojson }},
-                    borderColor: '#5AC53B',
-                    backgroundColor: 'rgba(90, 197, 59, 0.1)',
-                    fill: true,
-                    tension: 0.4,
-                    borderWidth: 3,
-                    pointBackgroundColor: '#5AC53B',
-                    pointBorderColor: '#1A1E23',
-                    pointBorderWidth: 2,
-                    pointRadius: 4
-                }]
-            },
-            options: {
-                responsive: true,
-                maintainAspectRatio: false,
-                scales: {
-                    y: {
-                        beginAtZero: false,
-                        ticks: {
-                            color: '#9CA0A6',
-                            callback: function(value) {
-                                return '$' + value.toLocaleString();
-                            }
-                        },
-                        grid: { color: '#3A404A' }
-                    },
-                    x: {
-                        ticks: { color: '#9CA0A6' },
-                        grid: { color: '#3A404A' }
-                    }
-                },
-                plugins: {
-                    legend: { display: false }
-                }
-            }
-        });
-        {% endif %}
-    </script>
-</body>
-</html>
-"""
+def refresh_dashboard_data() -> None:
+    """Refresh leaderboard cache."""
+    global dashboard_data
+    leaderboard, summary = fetch_leaderboard()
+    dashboard_data = {
+        "leaderboard": leaderboard,
+        "summary": summary,
+        "timestamp": time.time(),
+    }
 
 # ──────────────────────────────────────────────────────────────
 # Routes
@@ -1386,12 +432,17 @@ def health():
 
 @app.route("/")
 def index():
-    leaderboard, summary = fetch_leaderboard()
-    return render_template_string(
-        INDEX_HTML, 
-        leaderboard=leaderboard, 
-        summary=summary,
-        app_name=APP_NAME
+    current_time = time.time()
+    if (
+        dashboard_data["leaderboard"] is None
+        or current_time - dashboard_data["timestamp"] > DASHBOARD_CACHE_DURATION
+    ):
+        refresh_dashboard_data()
+    return render_template(
+        "index.html",
+        leaderboard=dashboard_data["leaderboard"],
+        summary=dashboard_data["summary"],
+        app_name=APP_NAME,
     )
 
 @app.route("/user/<user_id>")
@@ -1400,8 +451,8 @@ def user_detail(user_id):
     if not user_data:
         return redirect(url_for("index"))
 
-    return render_template_string(
-        USER_HTML,
+    return render_template(
+        "user.html",
         user=user_data,
         app_name=APP_NAME
     )
@@ -1409,8 +460,8 @@ def user_detail(user_id):
 @app.route("/api/refresh")
 def api_refresh():
     """API endpoint to refresh data without full page reload."""
-    leaderboard, summary = fetch_leaderboard()
-    return jsonify({"leaderboard": leaderboard, "summary": summary})
+    refresh_dashboard_data()
+    return jsonify({"leaderboard": dashboard_data["leaderboard"], "summary": dashboard_data["summary"]})
 
 # ──────────────────────────────────────────────────────────────
 # Run
@@ -1421,6 +472,7 @@ if __name__ == "__main__":
     # Preload price cache from database
     print("📈 Preloading price cache from database...")
     preload_price_cache()
+    refresh_dashboard_data()
     
     port = int(os.getenv("PORT", 8080))  # Use Fly.io's PORT or default to 8080
     print(f"📊 Dashboard will be available at: http://localhost:{port}")

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,503 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ app_name }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        /* Robinhood-Inspired Dark Theme */
+        :root {
+            --rh-black: #0B0E11;
+            --rh-dark: #1A1E23;
+            --rh-medium: #242932;
+            --rh-light: #2F343D;
+            --rh-border: #3A404A;
+            --rh-white: #FFFFFF;
+            --rh-text-primary: #FFFFFF;
+            --rh-text-secondary: #9CA0A6;
+            --rh-text-muted: #6B7280;
+            --rh-green: #00C805;
+            --rh-red: #FF5A52;
+            --rh-blue: #5AC53B;
+            --rh-purple: #8B5CF6;
+            --rh-yellow: #F7931E;
+        }
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: var(--rh-black);
+            color: var(--rh-text-primary);
+            font-size: 14px;
+            line-height: 1.5;
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+        
+        /* Navigation */
+        .navbar {
+            background: var(--rh-dark);
+            border-bottom: 1px solid var(--rh-border);
+            padding: 1rem 0;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+            backdrop-filter: blur(10px);
+        }
+        
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .nav-brand {
+            font-size: 1.25rem;
+            font-weight: 700;
+            color: var(--rh-white);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .nav-brand:hover {
+            color: var(--rh-blue);
+        }
+        
+        .nav-actions {
+            display: flex;
+            gap: 0.75rem;
+        }
+        
+        /* Buttons */
+        .btn {
+            padding: 0.5rem 1rem;
+            border-radius: 20px;
+            border: 1px solid transparent;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .btn-primary {
+            background: var(--rh-blue);
+            color: var(--rh-black);
+            border-color: var(--rh-blue);
+        }
+        
+        .btn-primary:hover {
+            background: #4AB02A;
+            transform: translateY(-1px);
+        }
+        
+        .btn-outline {
+            background: transparent;
+            color: var(--rh-text-secondary);
+            border-color: var(--rh-border);
+        }
+        
+        .btn-outline:hover {
+            background: var(--rh-medium);
+            color: var(--rh-white);
+            border-color: var(--rh-light);
+        }
+        
+        /* Container */
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        
+        /* Grid */
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+        
+        .grid-4 {
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+        
+        .grid-2 {
+            grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+        }
+        
+        /* Cards */
+        .card {
+            background: var(--rh-dark);
+            border: 1px solid var(--rh-border);
+            border-radius: 12px;
+            overflow: hidden;
+            transition: all 0.2s ease;
+        }
+        
+        .card:hover {
+            border-color: var(--rh-light);
+            transform: translateY(-2px);
+        }
+        
+        .card-header {
+            padding: 1.25rem 1.5rem;
+            border-bottom: 1px solid var(--rh-border);
+            background: var(--rh-medium);
+        }
+        
+        .card-title {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--rh-white);
+            margin: 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .card-body {
+            padding: 1.5rem;
+        }
+        
+        /* Metric Cards */
+        .metric-card {
+            text-align: center;
+            background: var(--rh-dark);
+            border: 1px solid var(--rh-border);
+            border-radius: 12px;
+            padding: 1.5rem;
+            transition: all 0.2s ease;
+        }
+        
+        .metric-card:hover {
+            border-color: var(--rh-light);
+            transform: translateY(-2px);
+        }
+        
+        .metric-icon {
+            font-size: 2rem;
+            margin-bottom: 0.75rem;
+            opacity: 0.8;
+        }
+        
+        .metric-label {
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--rh-text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 0.5rem;
+        }
+        
+        .metric-value {
+            font-size: 1.75rem;
+            font-weight: 700;
+            margin: 0;
+        }
+        
+        /* Table */
+        .table-container {
+            overflow-x: auto;
+            border-radius: 8px;
+            border: 1px solid var(--rh-border);
+        }
+        
+        .table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--rh-dark);
+        }
+        
+        .table th {
+            background: var(--rh-medium);
+            color: var(--rh-text-secondary);
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 1rem 0.75rem;
+            text-align: left;
+            border-bottom: 1px solid var(--rh-border);
+        }
+        
+        .table td {
+            padding: 1rem 0.75rem;
+            border-bottom: 1px solid var(--rh-border);
+            vertical-align: middle;
+        }
+        
+        .table tr:hover {
+            background: var(--rh-medium);
+        }
+        
+        .table tr:last-child td {
+            border-bottom: none;
+        }
+        
+        /* Colors */
+        .text-green {
+            color: var(--rh-green);
+            font-weight: 600;
+        }
+        
+        .text-red {
+            color: var(--rh-red);
+            font-weight: 600;
+        }
+        
+        .text-blue {
+            color: var(--rh-blue);
+        }
+        
+        .text-yellow {
+            color: var(--rh-yellow);
+        }
+        
+        .text-purple {
+            color: var(--rh-purple);
+        }
+        
+        .text-secondary {
+            color: var(--rh-text-secondary);
+        }
+        
+        .text-muted {
+            color: var(--rh-text-muted);
+            font-size: 13px;
+        }
+        
+        /* Badges */
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.25rem;
+            padding: 0.25rem 0.75rem;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+        
+        .badge-gold {
+            background: linear-gradient(135deg, var(--rh-yellow), #E67E22);
+            color: var(--rh-black);
+        }
+        
+        .badge-silver {
+            background: var(--rh-text-secondary);
+            color: var(--rh-black);
+        }
+        
+        /* Charts */
+        .chart-container {
+            position: relative;
+            height: 300px;
+            background: var(--rh-medium);
+            border-radius: 8px;
+            padding: 1rem;
+        }
+        
+        /* Loading */
+        .loading {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 0.5rem;
+            color: var(--rh-text-secondary);
+            font-size: 14px;
+        }
+        
+        .spinner {
+            width: 16px;
+            height: 16px;
+            border: 2px solid var(--rh-border);
+            border-top: 2px solid var(--rh-blue);
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+        }
+        
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+        
+        /* Responsive */
+        @media (max-width: 768px) {
+            .container {
+                padding: 1rem;
+            }
+            
+            .metric-card {
+                padding: 1rem;
+            }
+            
+            .metric-value {
+                font-size: 1.5rem;
+            }
+            
+            .table th,
+            .table td {
+                padding: 0.75rem 0.5rem;
+                font-size: 13px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="/" class="nav-brand">
+                <i class="fas fa-chart-line"></i>
+                {{ app_name }}
+            </a>
+            <div class="nav-actions">
+                <button class="btn btn-primary" onclick="refreshData()">
+                    <i class="fas fa-sync-alt"></i>
+                    Refresh
+                </button>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <!-- Market Summary -->
+        <div class="grid grid-4" style="margin-bottom: 2rem;">
+            <div class="metric-card">
+                <div class="metric-icon text-blue">
+                    <i class="fas fa-users"></i>
+                </div>
+                <div class="metric-label">Active Traders</div>
+                <div class="metric-value text-blue">{{ summary.total_users }}</div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-green">
+                    <i class="fas fa-dollar-sign"></i>
+                </div>
+                <div class="metric-label">Total AUM</div>
+                <div class="metric-value text-green">${{ "{:,.0f}".format(summary.total_aum) }}</div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-yellow">
+                    <i class="fas fa-chart-line"></i>
+                </div>
+                <div class="metric-label">Avg ROI</div>
+                <div class="metric-value {% if summary.avg_roi >= 0 %}text-green{% else %}text-red{% endif %}">
+                    {{ "{:+.1f}".format(summary.avg_roi) }}%
+                </div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-purple">
+                    <i class="fas fa-trophy"></i>
+                </div>
+                <div class="metric-label">Best Performer</div>
+                <div class="metric-value text-purple">{{ summary.best_performer }}</div>
+            </div>
+        </div>
+
+        <!-- Leaderboard -->
+        <div class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    <i class="fas fa-trophy text-yellow"></i>
+                    Leaderboard
+                </h2>
+            </div>
+            <div class="card-body" style="padding: 0;">
+                <div class="table-container">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th><i class="fas fa-medal"></i> Rank</th>
+                                <th><i class="fas fa-user"></i> Trader</th>
+                                <th><i class="fas fa-wallet"></i> Cash</th>
+                                <th><i class="fas fa-chart-pie"></i> Holdings</th>
+                                <th><i class="fas fa-money-bill"></i> Total Value</th>
+                                <th><i class="fas fa-percentage"></i> ROI</th>
+                                <th><i class="fas fa-chart-line"></i> P&L</th>
+                                <th><i class="fas fa-eye"></i> Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for user in leaderboard %}
+                            <tr>
+                                <td>
+                                    {% if loop.index == 1 %}
+                                        <span class="badge badge-gold">
+                                            <i class="fas fa-crown"></i> {{ loop.index }}
+                                        </span>
+                                    {% elif loop.index <= 3 %}
+                                        <span class="badge badge-silver">{{ loop.index }}</span>
+                                    {% else %}
+                                        <span style="font-weight: 600;">{{ loop.index }}</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <div>
+                                        <div style="font-weight: 600;">{{ user.name }}</div>
+                                        {% if user.total_holdings > 0 %}
+                                            <div class="text-muted">{{ user.total_holdings }} positions</div>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                                <td>${{ "{:,.0f}".format(user.cash) }}</td>
+                                <td>${{ "{:,.0f}".format(user.holdings_value) }}</td>
+                                <td style="font-weight: 700;">${{ "{:,.0f}".format(user.total_value) }}</td>
+                                <td class="{% if user.roi >= 0 %}text-green{% else %}text-red{% endif %}">
+                                    {{ "{:+.1f}".format(user.roi) }}%
+                                </td>
+                                <td class="{% if user.pnl >= 0 %}text-green{% else %}text-red{% endif %}">
+                                    ${{ "{:+,.0f}".format(user.pnl) }}
+                                </td>
+                                <td>
+                                    <a href="/user/{{ user.user_id }}" class="btn btn-outline">
+                                        <i class="fas fa-chart-area"></i>
+                                        View Portfolio
+                                    </a>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        function refreshData() {
+            const spinner = document.querySelector('.spinner');
+            if (spinner) return; // Already refreshing
+            
+            const refreshBtn = document.querySelector('.btn-primary');
+            const originalContent = refreshBtn.innerHTML;
+            
+            refreshBtn.innerHTML = '<div class="spinner"></div> Refreshing...';
+            refreshBtn.disabled = true;
+            
+            setTimeout(() => {
+                location.reload();
+            }, 1000);
+        }
+    </script>
+</body>
+</html>

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ user.name }} - Portfolio | {{ app_name }}</title>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        /* Same styles as INDEX_HTML for consistency */
+        :root {
+            --rh-black: #0B0E11;
+            --rh-dark: #1A1E23;
+            --rh-medium: #242932;
+            --rh-light: #2F343D;
+            --rh-border: #3A404A;
+            --rh-white: #FFFFFF;
+            --rh-text-primary: #FFFFFF;
+            --rh-text-secondary: #9CA0A6;
+            --rh-text-muted: #6B7280;
+            --rh-green: #00C805;
+            --rh-red: #FF5A52;
+            --rh-blue: #5AC53B;
+            --rh-purple: #8B5CF6;
+            --rh-yellow: #F7931E;
+        }
+        
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: var(--rh-black);
+            color: var(--rh-text-primary);
+            font-size: 14px;
+            line-height: 1.5;
+            min-height: 100vh;
+            overflow-x: hidden;
+        }
+        
+        .navbar {
+            background: var(--rh-dark);
+            border-bottom: 1px solid var(--rh-border);
+            padding: 1rem 0;
+            position: sticky;
+            top: 0;
+            z-index: 100;
+        }
+        
+        .nav-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 0 1rem;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+        
+        .nav-brand {
+            font-size: 1.25rem;
+            font-weight: 700;
+            color: var(--rh-white);
+            text-decoration: none;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .btn {
+            padding: 0.5rem 1rem;
+            border-radius: 20px;
+            border: 1px solid transparent;
+            font-size: 13px;
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .btn-outline {
+            background: transparent;
+            color: var(--rh-text-secondary);
+            border-color: var(--rh-border);
+        }
+        
+        .btn-outline:hover {
+            background: var(--rh-medium);
+            color: var(--rh-white);
+            border-color: var(--rh-light);
+        }
+        
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 2rem 1rem;
+        }
+        
+        .grid {
+            display: grid;
+            gap: 1.5rem;
+        }
+        
+        .grid-4 {
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+        
+        .grid-2 {
+            grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+        }
+        
+        .card {
+            background: var(--rh-dark);
+            border: 1px solid var(--rh-border);
+            border-radius: 12px;
+            overflow: hidden;
+        }
+        
+        .card-header {
+            padding: 1.25rem 1.5rem;
+            border-bottom: 1px solid var(--rh-border);
+            background: var(--rh-medium);
+        }
+        
+        .card-title {
+            font-size: 1rem;
+            font-weight: 600;
+            color: var(--rh-white);
+            margin: 0;
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        
+        .card-body {
+            padding: 1.5rem;
+        }
+        
+        .metric-card {
+            text-align: center;
+            background: var(--rh-dark);
+            border: 1px solid var(--rh-border);
+            border-radius: 12px;
+            padding: 1.5rem;
+            transition: all 0.2s ease;
+        }
+        
+        .metric-card:hover {
+            border-color: var(--rh-light);
+            transform: translateY(-2px);
+        }
+        
+        .metric-icon {
+            font-size: 2rem;
+            margin-bottom: 0.75rem;
+            opacity: 0.8;
+        }
+        
+        .metric-label {
+            font-size: 12px;
+            font-weight: 500;
+            color: var(--rh-text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 0.5rem;
+        }
+        
+        .metric-value {
+            font-size: 1.75rem;
+            font-weight: 700;
+            margin: 0;
+        }
+        
+        .table-container {
+            overflow-x: auto;
+            border-radius: 8px;
+            border: 1px solid var(--rh-border);
+        }
+        
+        .table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--rh-dark);
+        }
+        
+        .table th {
+            background: var(--rh-medium);
+            color: var(--rh-text-secondary);
+            font-size: 12px;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            padding: 1rem 0.75rem;
+            text-align: left;
+            border-bottom: 1px solid var(--rh-border);
+        }
+        
+        .table td {
+            padding: 1rem 0.75rem;
+            border-bottom: 1px solid var(--rh-border);
+            vertical-align: middle;
+        }
+        
+        .table tr:hover {
+            background: var(--rh-medium);
+        }
+        
+        .text-green {
+            color: var(--rh-green);
+            font-weight: 600;
+        }
+        
+        .text-red {
+            color: var(--rh-red);
+            font-weight: 600;
+        }
+        
+        .text-blue {
+            color: var(--rh-blue);
+        }
+        
+        .text-yellow {
+            color: var(--rh-yellow);
+        }
+        
+        .text-purple {
+            color: var(--rh-purple);
+        }
+        
+        .text-muted {
+            color: var(--rh-text-muted);
+            font-size: 13px;
+        }
+        
+        .chart-container {
+            position: relative;
+            height: 300px;
+            background: var(--rh-medium);
+            border-radius: 8px;
+            padding: 1rem;
+        }
+        
+        .page-title {
+            text-align: center;
+            margin-bottom: 2rem;
+            color: var(--rh-white);
+            font-size: 1.75rem;
+            font-weight: 700;
+        }
+        
+        @media (max-width: 768px) {
+            .container {
+                padding: 1rem;
+            }
+            
+            .metric-card {
+                padding: 1rem;
+            }
+            
+            .metric-value {
+                font-size: 1.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- Navigation -->
+    <nav class="navbar">
+        <div class="nav-container">
+            <a href="/" class="nav-brand">
+                <i class="fas fa-chart-line"></i>
+                {{ app_name }}
+            </a>
+            <div class="nav-actions">
+                <a href="/" class="btn btn-outline">
+                    <i class="fas fa-arrow-left"></i>
+                    Back to Leaderboard
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="container">
+        <!-- User Header -->
+        <h1 class="page-title">
+            <i class="fas fa-user-circle"></i>
+            {{ user.name }}'s Portfolio
+        </h1>
+
+        <!-- Portfolio Summary Cards -->
+        <div class="grid grid-4" style="margin-bottom: 2rem;">
+            <div class="metric-card">
+                <div class="metric-icon text-green">
+                    <i class="fas fa-wallet"></i>
+                </div>
+                <div class="metric-label">Cash</div>
+                <div class="metric-value text-green">${{ "{:,.0f}".format(user.cash) }}</div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-blue">
+                    <i class="fas fa-chart-pie"></i>
+                </div>
+                <div class="metric-label">Holdings Value</div>
+                <div class="metric-value text-blue">${{ "{:,.0f}".format(user.holdings_value) }}</div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-purple">
+                    <i class="fas fa-money-bill"></i>
+                </div>
+                <div class="metric-label">Total Value</div>
+                <div class="metric-value text-purple">${{ "{:,.0f}".format(user.total_value) }}</div>
+            </div>
+            
+            <div class="metric-card">
+                <div class="metric-icon text-yellow">
+                    <i class="fas fa-percentage"></i>
+                </div>
+                <div class="metric-label">ROI</div>
+                <div class="metric-value {% if user.roi >= 0 %}text-green{% else %}text-red{% endif %}">
+                    {{ "{:+.1f}".format(user.roi) }}%
+                </div>
+            </div>
+        </div>
+
+        <!-- Charts Row -->
+        <div class="grid grid-2" style="margin-bottom: 2rem;">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">
+                        <i class="fas fa-chart-pie"></i>
+                        Portfolio Allocation
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <div class="chart-container">
+                        <canvas id="pieChart"></canvas>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">
+                        <i class="fas fa-chart-line"></i>
+                        Performance Over Time
+                    </h3>
+                </div>
+                <div class="card-body">
+                    <div class="chart-container">
+                        <canvas id="lineChart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Holdings Table -->
+        {% if user.holdings %}
+        <div class="card">
+            <div class="card-header">
+                <h3 class="card-title">
+                    <i class="fas fa-list"></i>
+                    Holdings Details
+                </h3>
+            </div>
+            <div class="card-body" style="padding: 0;">
+                <div class="table-container">
+                    <table class="table">
+                        <thead>
+                            <tr>
+                                <th><i class="fas fa-tag"></i> Stock</th>
+                                <th><i class="fas fa-layer-group"></i> Shares</th>
+                                <th><i class="fas fa-dollar-sign"></i> Avg Cost</th>
+                                <th><i class="fas fa-chart-line"></i> Current Price</th>
+                                <th><i class="fas fa-money-bill"></i> Position Value</th>
+                                <th><i class="fas fa-percentage"></i> Price Change</th>
+                                <th><i class="fas fa-calculator"></i> Unrealized P&L</th>
+                                <th><i class="fas fa-chart-pie"></i> % of Portfolio</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                        {% for h in user.holdings %}
+                            <tr>
+                                <td>
+                                    <div>
+                                        <div style="font-weight: 600;">{{ h.symbol }}</div>
+                                        <div class="text-muted">{{ h.company_name }}</div>
+                                    </div>
+                                </td>
+                                <td>{{ "{:,.0f}".format(h.shares) }}</td>
+                                <td>${{ "{:.2f}".format(h.avg_price) }}</td>
+                                <td>${{ "{:.2f}".format(h.price) }}</td>
+                                <td style="font-weight: 700;">${{ "{:,.0f}".format(h.value) }}</td>
+                                <td class="{% if h.change >= 0 %}text-green{% else %}text-red{% endif %}">
+                                    {{ "{:+.1f}".format(h.change) }}%
+                                </td>
+                                <td class="{% if h.unrealized_pnl >= 0 %}text-green{% else %}text-red{% endif %}">
+                                    ${{ "{:+,.0f}".format(h.unrealized_pnl) }}
+                                </td>
+                                <td>{{ "{:.1f}".format(h.portfolio_percent) }}%</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        {% else %}
+        <div class="card">
+            <div class="card-body" style="text-align: center; padding: 3rem;">
+                <div style="font-size: 3rem; color: var(--rh-text-muted); margin-bottom: 1rem;">
+                    <i class="fas fa-chart-pie"></i>
+                </div>
+                <h3 style="color: var(--rh-text-secondary); margin-bottom: 0.5rem;">No Holdings Yet</h3>
+                <p class="text-muted">This portfolio consists entirely of cash.</p>
+            </div>
+        </div>
+        {% endif %}
+    </div>
+
+    <script>
+        // Chart.js configuration for consistent dark theme
+        Chart.defaults.color = '#9CA0A6';
+        Chart.defaults.borderColor = '#3A404A';
+        Chart.defaults.backgroundColor = '#242932';
+
+        // Pie Chart for Portfolio Allocation
+        {% if user.pie_labels|length > 0 %}
+        const pieCtx = document.getElementById('pieChart').getContext('2d');
+        new Chart(pieCtx, {
+            type: 'doughnut',
+            data: {
+                labels: {{ user.pie_labels|tojson }},
+                datasets: [{
+                    data: {{ user.pie_values|tojson }},
+                    backgroundColor: [
+                        '#00C805', '#FF5A52', '#5AC53B', '#8B5CF6', 
+                        '#F7931E', '#06B6D4', '#EF4444', '#10B981',
+                        '#F59E0B', '#8B5CF6'
+                    ],
+                    borderWidth: 2,
+                    borderColor: '#1A1E23'
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { 
+                        position: 'right',
+                        labels: { 
+                            color: '#9CA0A6',
+                            usePointStyle: true,
+                            padding: 20
+                        }
+                    }
+                }
+            }
+        });
+        {% endif %}
+
+        // Line Chart for Historical Performance
+        {% if user.history_dates|length > 0 %}
+        const lineCtx = document.getElementById('lineChart').getContext('2d');
+        new Chart(lineCtx, {
+            type: 'line',
+            data: {
+                labels: {{ user.history_dates|tojson }},
+                datasets: [{
+                    label: 'Portfolio Value',
+                    data: {{ user.history_values|tojson }},
+                    borderColor: '#5AC53B',
+                    backgroundColor: 'rgba(90, 197, 59, 0.1)',
+                    fill: true,
+                    tension: 0.4,
+                    borderWidth: 3,
+                    pointBackgroundColor: '#5AC53B',
+                    pointBorderColor: '#1A1E23',
+                    pointBorderWidth: 2,
+                    pointRadius: 4
+                }]
+            },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                scales: {
+                    y: {
+                        beginAtZero: false,
+                        ticks: {
+                            color: '#9CA0A6',
+                            callback: function(value) {
+                                return '$' + value.toLocaleString();
+                            }
+                        },
+                        grid: { color: '#3A404A' }
+                    },
+                    x: {
+                        ticks: { color: '#9CA0A6' },
+                        grid: { color: '#3A404A' }
+                    }
+                },
+                plugins: {
+                    legend: { display: false }
+                }
+            }
+        });
+        {% endif %}
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- throttle API requests with `MIN_REQUEST_INTERVAL`
- cache leaderboard data using `DASHBOARD_CACHE_DURATION`
- add Yahoo Finance fallback and persist last prices
- switch Flask routes to render templates
- remove stray template delimiters and unused import

## Testing
- `python -m py_compile dashboard_robinhood.py`
- `python validate.py` *(fails: missing local .env)*

------
https://chatgpt.com/codex/tasks/task_e_68478fecdf448330a0bbc83d73a0936b