### PR TITLE
Enable long-term price and name caching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,5 +12,11 @@ FINNHUB_API_KEY_2=your_alternate_finnhub_api_key_here
 DISCORD_CHANNEL_ID=your_discord_channel_id_here
 
 # Dashboard caching and rate limiting
+# Dashboard update frequency (seconds)
 DASHBOARD_CACHE_DURATION=300
+# Minimum seconds between API calls (shared by bot & dashboard)
 MIN_REQUEST_INTERVAL=2
+# Price caching (seconds)
+PRICE_CACHE_TTL=14400
+# Company name caching (seconds)
+COMPANY_CACHE_TTL=86400

--- a/README.md
+++ b/README.md
@@ -276,6 +276,9 @@ Create a `.env` file (you can copy from `.env.example`) with:
 TOKEN=your_discord_bot_token
 FINNHUB_API_KEY=your_finnhub_api_key
 DISCORD_CHANNEL_ID=your_discord_channel_id
+MIN_REQUEST_INTERVAL=2  # min seconds between API calls
+PRICE_CACHE_TTL=14400  # price cache duration in seconds
+COMPANY_CACHE_TTL=86400  # company name cache duration
 ```
 
 **How to Obtain Required Keys:**


### PR DESCRIPTION
## Summary
- make cache TTL defaults much longer to minimize API calls
- add optional company name caching in bot and dashboard
- document new `COMPANY_CACHE_TTL` env var
- fix env example comments

## Testing
- `python -m py_compile botsim_enhanced.py dashboard_robinhood.py`
- `python validate.py` *(fails: TOKEN, FINNHUB_API_KEY, DISCORD_CHANNEL_ID not set)*

------
https://chatgpt.com/codex/tasks/task_e_684799ea15a88330acbd66fdcad3afb6